### PR TITLE
setting up association service, contracts and extracting given fields…

### DIFF
--- a/association_tourneys_users/src/schema.py
+++ b/association_tourneys_users/src/schema.py
@@ -1,16 +1,11 @@
-import pprint as pp
-import copy
-import json
+from pprint import pformat
 import requests
-from graphql import GraphQLSchema, build_client_schema
-import graphene
-from graphene import Connection, JSONString, relay, Field, ObjectType, Schema, String, List, Boolean, Int
+from graphene import Connection, relay, Field, ObjectType, Schema
 from . import utils
 from . import schema_associations
 from . import client
 from gql import gql, Client
 from gql.transport.requests import RequestsHTTPTransport
-
 
 class Query(ObjectType):
     node = relay.Node.Field()
@@ -19,13 +14,13 @@ class Query(ObjectType):
     # parameters that are listed in the schema.
     # users_list = relay.Node.Field(schema_associations.UsersList)
     users_list = Field(schema_associations.UsersList) 
-    tournament_list = graphene.Field(schema_associations.TournamentList) 
+    tournament_list = Field(schema_associations.TournamentList) 
 
-    def resolve_users_list(self, info, *args):
+    def resolve_users_list(self, info):
         results = utils.get_user_list_client()
         return results
 
-    def resolve_tournament_list(self, info, *args):
+    def resolve_tournament_list(self, info):
         results = utils.get_tournament_list()
         return results
 

--- a/association_tourneys_users/src/schema_associations.py
+++ b/association_tourneys_users/src/schema_associations.py
@@ -9,6 +9,13 @@ from . import client
 the models itself. 
 '''
 
+class User(ObjectType):
+    id = String()
+    name = String()
+    steamId = String()
+    created = String()
+    edited = String()
+
 class Tournament(ObjectType):
     id = String()
     name = String()
@@ -16,13 +23,8 @@ class Tournament(ObjectType):
     edited = String()
     maxParticipants = Int()
     minParticipants = Int()
-
-class User(ObjectType):
-    id = String()
-    name = String()
-    steamId = String()
-    created = String()
-    edited = String()
+    # participants = graphene.Field(User)
+    participants = String()
 
 class UsersList(graphene.Connection):
     class Meta:
@@ -31,6 +33,3 @@ class UsersList(graphene.Connection):
 class TournamentList(graphene.Connection):
     class Meta:
         node = Tournament
-
-class Unite(graphene.Union):
-    pass

--- a/tournaments_crud/src/database/model_tournaments.py
+++ b/tournaments_crud/src/database/model_tournaments.py
@@ -13,5 +13,6 @@ class ModelTournaments(Base):
     min_participants = Column('min_participants', Integer, default=2)
     created = Column('created', String, doc="Creation date of Tournament.")
     edited = Column('edited', String, doc="Edited date of Tournament.")
+    participants = Column('participants', String, doc="String of global IDs")
 
     UniqueConstraint(name)

--- a/tournaments_crud/src/schema_tournaments.py
+++ b/tournaments_crud/src/schema_tournaments.py
@@ -11,7 +11,8 @@ class TournamentAttribute:
     name = graphene.String(description="Name of Tournament.")
     max_participants = graphene.Int(description="Max number of participants.")
     min_participants = graphene.Int(description="Min number of participants.")
-    list_of_participants = graphene.List(description="List of Participants Global ID")
+    # list_of_participants = graphene.List(description="List of Participants Global ID")
+    participants = graphene.String(description="List of Participants Global ID")
 
 
 class Tournament(SQLAlchemyObjectType):
@@ -63,6 +64,8 @@ class UpdateTournament(graphene.Mutation):
         data['edited'] = datetime.utcnow()
 
         tournament = db_session.query(ModelTournaments).filter_by(id=data['id'])
+        tournament_row = tournament.first()
+        data['participants'] += ';' + str(tournament_row.participants)
         tournament.update(data)
         db_session.commit()
         tournament = db_session.query(ModelTournaments).filter_by(id=data['id']).first()

--- a/tournaments_crud/src/setup.py
+++ b/tournaments_crud/src/setup.py
@@ -1,4 +1,5 @@
 #! usr/bin/python3.7
+from pprint import pformat
 from ast import literal_eval
 from database.model_tournaments import ModelTournaments
 from database import base
@@ -13,6 +14,16 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 if __name__ == '__main__':
-    log.info('Created database {}'.format(base.db_name))
+    log.info(pformat('Created database {}'.format(base.db_name), indent=2))
+    base.Base.metadata.drop_all(base.engine)
     base.Base.metadata.create_all(base.engine)
-    log.info('Table users DESC: {}'.format(base.Base.metadata.tables))
+    log.info(pformat('Table users DESC: {}'.format(base.Base.metadata.tables),
+        indent=2))
+
+    log.info('Inserting Tournament Data')
+    with open('database/data/tournaments.json', 'r') as file:
+        data = literal_eval(file.read())
+        for record in data:
+            tournament = ModelTournaments(**record)
+            base.db_session.add(tournament)
+        base.db_session.commit()

--- a/users_crud/src/database/model_users.py
+++ b/users_crud/src/database/model_users.py
@@ -12,11 +12,10 @@ class ModelUsers(Base):
     __tablename__ = 'users'
     id = Column('id', Integer, primary_key=True, doc='PK Id of User.')
     name = Column('name', String, doc="Name of User.")
-    first_name = Column('first_name', String,nullable=False, doc="First Name of User.")
-    middle_name = Column('middle_name', String, doc="Middle Name of User.")
-    last_name = Column('last_name', String, nullable=False, doc="Last Name of User.")
+    # first_name = Column('first_name', String,nullable=False, doc="First Name of User.")
+    # middle_name = Column('middle_name', String, doc="Middle Name of User.")
+    # last_name = Column('last_name', String, nullable=False, doc="Last Name of User.")
     steam_Id = Column('steamId', Integer, doc="Steam ID of User.")
     created = Column('created', String, doc="Creation time of User.")
     edited = Column('edited', String, doc="Edited time of User.")
-    owner_tournament = Column('owner_tournament', ARRAY(String), doc="Stores of global IDs this user has created.")
-
+    # owner_tournament = Column('owner_tournament', ARRAY(String), doc="Stores of global IDs this user has created.")

--- a/users_crud/src/schema_users.py
+++ b/users_crud/src/schema_users.py
@@ -9,12 +9,12 @@ from . import utils
 # Create Generic class to mutualize description of User attributes for both queries.
 class UserAttribute:
     name = graphene.String(description="Name of User.")
-    first_name = graphene.String(description="First Name of User.")
-    middle_first_name = graphene.String(description="Middle Name of User.")
-    last_name = graphene.String(description="Last Name of User.")
+    # first_name = graphene.String(description="First Name of User.")
+    # middle_first_name = graphene.String(description="Middle Name of User.")
+    # last_name = graphene.String(description="Last Name of User.")
     steam_Id = graphene.Int(description="Steam ID of User.")
-    attending_tournament = graphene.List(description="List of Tournament Global IDs")
-    owner_tournament = graphene.List(description="List of Tournament Global ID as Owner")
+    # attending_tournament = graphene.List(description="List of Tournament Global IDs")
+    # owner_tournament = graphene.List(description="List of Tournament Global ID as Owner")
 
 
 class User(SQLAlchemyObjectType):

--- a/users_crud/src/setup.py
+++ b/users_crud/src/setup.py
@@ -1,3 +1,4 @@
+from pprint import pformat
 from ast import literal_eval
 from database.model_users import ModelUsers
 from database import base
@@ -12,6 +13,16 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 if __name__ == '__main__':
-    log.info('Created database {}'.format(base.db_name))
+    log.info(pformat('Created database {}'.format(base.db_name), indent=2))
+    base.Base.metadata.drop_all(base.engine)
     base.Base.metadata.create_all(base.engine)
-    log.info('Table users DESC: {}'.format(base.Base.metadata.tables))
+    log.info(pformat('Table users DESC: {}'.format(base.Base.metadata.tables),
+        indent=2))
+
+    log.info('Inserting User Data')
+    with open('database/data/users.json', 'r') as file:
+        data = literal_eval(file.read())
+        for record in data:
+            user = ModelUsers(**record)
+            base.db_session.add(user)
+        base.db_session.commit()


### PR DESCRIPTION
Function in Association_tourneys_users.src.utils 'my_get_fields(info)' is given along with a 'test' and 'test_collect_fields' which might not be needed in future, the test was grabbed from one of the github repositories on `graphene/ast_to_dict`.
* Association micro-service now requests data from other tournaments and users CRUD services, but the 1 + n querying issue has not been solved. That's why the 'get_fields' methods were implemented so a user can request the given fields. 